### PR TITLE
Lein middlewares to version RPMs with Primedia's convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /checkouts
 /.lein-deps-sum
 *~
+/.nrepl-port

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,12 @@
 (defproject lein-rpm "0.0.6-SNAPSHOT"
   :description "Create an RPM"
   :dependencies [[org.codehaus.mojo/rpm-maven-plugin "2.1-alpha-1"]
+                 [clj-yaml "0.4.1-SNAPSHOT"]
                  [org.clojure/java.data "0.1.1"]]
   :eval-in-leiningen true
-  :plugins [[lein-pprint "1.1.1"]])
+  :plugins [[lein-pprint "1.1.1"]]
+
+  :repositories [["primedia" {:url "http://nexus.idg.primedia.com/nexus/content/repositories/primedia"
+                              :sign-releases false}]
+                 ["snapshots" {:url "http://nexus.idg.primedia.com/nexus/content/repositories/snapshots"
+                               :sign-releases false}]])

--- a/src/leiningen/rpm.clj
+++ b/src/leiningen/rpm.clj
@@ -48,9 +48,11 @@
 
 (defn rpm
   "Create an RPM"
-  [{{:keys [summary name copyright mappings prefix preinstall postinstall preremove postremove requires provides conflicts workarea]} :rpm :keys [version]} & keys]
+  [{{:keys [summary name release copyright mappings prefix preinstall postinstall preremove postremove requires provides conflicts workarea]} :rpm
+    :keys [version]} & keys]
   (let [mojo (createBaseMojo)]
     (set-mojo! mojo "projversion" version)
+    (set-mojo! mojo "release" release)
     (set-mojo! mojo "name" name)
     (set-mojo! mojo "summary" summary)
     (set-mojo! mojo "copyright" copyright)

--- a/src/leiningen/rpm/build_info.clj
+++ b/src/leiningen/rpm/build_info.clj
@@ -1,0 +1,16 @@
+(ns leiningen.rpm.build-info
+  (:require [clj-yaml.core :as yaml]))
+
+(def ^:private +build-info-file+ "./BUILD_INFO")
+
+(defn build-info
+  ([]
+     (build-info +build-info-file+))
+  ([filename]
+     (yaml/parse-string (slurp filename))))
+
+;; ./build_info.yml 
+;; ---
+;; revision: 1fec6781fe2de97fe6be92edec7065d19bd61ac5
+;; version: '2014_04_18_15_04'
+;; build_time: 2014-04-18 15:04:43.588829000 -04:00

--- a/src/leiningen/rpm/middleware.clj
+++ b/src/leiningen/rpm/middleware.clj
@@ -1,0 +1,10 @@
+(ns leiningen.rpm.middleware
+  (:require [leiningen.rpm.build-info :refer [build-info]]))
+
+(defn build-info->version
+  [project]
+  (assoc project :version (:version (build-info))))
+
+(defn build-info->release
+  [project]
+  (assoc-in project [:rpm :release] (.substring (:revision (build-info)) 0 7)))


### PR DESCRIPTION
- RPM version is the build datetime formatted: yyyy_MM_dd_mm_ss
- RPM revision is the first 7 chars of the git commit hash
