### PR TITLE
Making lein-rpm work with latest rpm-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ options that are available.
             :summary "RPM summary"
             :copyright "Andrew H Jones"
             :workarea "target"
+            :requires ["trash-truck > 1.0"]
+			:preinstall {:scriptfile "script.sh"}
             :mappings [{:directory "/usr/local/bin/landfill"
                         :filemode "440"
                         :username "dumper"
                         :groupname "dumpgroup"
-                        :preinstall {:scriptfile "script.sh"}
-                        :requires ["trash-truck > 1.0"]
                         ;; There are also postinstall, preremove and postremove
                         :sources {:source [{:location "target/classes"}
                                            {:location "src"}]

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject lein-rpm "0.0.6-SNAPSHOT"
   :description "Create an RPM"
-  :dependencies [[org.codehaus.mojo/rpm-maven-plugin "2.1-alpha-1"]
+  :dependencies [[org.codehaus.mojo/rpm-maven-plugin "2.1.5"]
                  [org.clojure/java.data "0.1.1"]]
   :eval-in-leiningen true
   :plugins [[lein-pprint "1.1.1"]])

--- a/src/leiningen/rpm.clj
+++ b/src/leiningen/rpm.clj
@@ -39,7 +39,7 @@
   (if-let [v (get m k)] (assoc m k (f v)) m))
 
 (defn create-scriptlet [s]
-  (data/to-java Scriptlet (if-key-update s :scriptFile #(clojure.java.io/file %))))
+  (data/to-java Scriptlet (if-key-update s :script-file #(clojure.java.io/file %))))
 
 (defn create-dependency [rs]
   (let [hs (java.util.LinkedHashSet.)]
@@ -48,13 +48,19 @@
 
 (defn rpm
   "Create an RPM"
-  [{{:keys [summary name copyright mappings prefix preinstall postinstall preremove postremove requires provides conflicts workarea]} :rpm :keys [version]} & keys]
+  [{{:keys [summary group name target-arch target-os target-vendor mappings
+            prefix preinstall postinstall preremove postremove requires provides
+            conflicts workarea]} :rpm
+    :keys [version]}]
   (let [mojo (createBaseMojo)]
     (set-mojo! mojo "projversion" version)
     (set-mojo! mojo "name" name)
     (set-mojo! mojo "summary" summary)
-    (set-mojo! mojo "copyright" copyright)
-    (set-mojo! mojo "workarea" (clojure.java.io/file workarea)) 
+    (set-mojo! mojo "group" group)
+    (set-mojo! mojo "targetArch" target-arch)
+    (set-mojo! mojo "targetOS" target-os)
+    (set-mojo! mojo "targetVendor" target-vendor)
+    (set-mojo! mojo "workarea" (clojure.java.io/file workarea))
     (set-mojo! mojo "mappings" (create-array-list (create-mappings mappings)))
     (set-mojo! mojo "prefix" prefix)
     (set-mojo! mojo "preinstallScriptlet" (create-scriptlet preinstall))


### PR DESCRIPTION
There have been several changes to rpm-maven-plugin since the last
release of lein-rpm, this makes the necessary updates to lein-rpm to
make it work again.
